### PR TITLE
Support proxy environment

### DIFF
--- a/rest/restClient.go
+++ b/rest/restClient.go
@@ -39,6 +39,7 @@ type Response struct {
 
 func New() *RestClient {
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	httpClient := &http.Client{


### PR DESCRIPTION
Currently kcinit doesn't support proxy environment because `RestClient` has own Transport which doesn't look at proxy setting. I added `Proxy` option for supporting it.